### PR TITLE
Fix Laravel Versoin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kozz/laravel-guzzle-provider",
-    "description": "Guzzle Service Provider for Laravel 6",
+    "description": "Guzzle 5/6 Service Provider for Laravel",
     "keywords": ["laravel", "guzzle", "http"],
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Laravel 6 isn't out yet. This updates the package description to reflect guzzle 6 compatibility.