### PR TITLE
Laravel 6.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "illuminate/support": "~5.0",
+        "php": "^7.2.0",
+        "illuminate/support": "^5.0 | ^6.0",
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2.0",
         "illuminate/support": "^5.0 | ^6.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Kozz\\Laravel\\": "src/",
+            "Kozz\\Laravel\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Kozz\\Tests\\Laravel\\": "tests/"
         }
     },


### PR DESCRIPTION
- Replaced `illuminate/support` version from `~5.0` to `^5.0 | ^6.0`.
- Replaced Guzzle version (`~6.0`) with more semver-compatible `^6.0`
- Moved `Kozz\\Tests\\Laravel` namespace to not register when the plugin is used, only when developing the plugin (using `autoload-dev`)